### PR TITLE
Fix favicon.ico href path

### DIFF
--- a/lib/jekyll/favicon/templates/classic.html.erb
+++ b/lib/jekyll/favicon/templates/classic.html.erb
@@ -1,7 +1,8 @@
 <!-- Classic -->
-<link rel="shortcut icon" href="favicon.ico">
+<%- favicon_ico_path = File.join prepend_path, Favicon.config['ico']['path'] -%>
+<link rel="shortcut icon" href="<%= File.join favicon_ico_path, 'favicon.ico' %>">
+<link rel="icon" sizes="<%= Favicon.config['ico']['sizes'].collect{|s| "#{s}x#{s}"}.join ' ' %>" href="<%= File.join favicon_ico_path, 'favicon.ico' %>">
 <%- favicon_path = File.join prepend_path, Favicon.config['path'] -%>
-<link rel="icon" sizes="<%= Favicon.config['ico']['sizes'].collect{|s| "#{s}x#{s}"}.join ' ' %>" href="<%= File.join favicon_path, 'favicon.ico' %>">
 <%- Favicon.config['classic']['sizes'].each do |size| -%>
   <link rel="icon" sizes="<%= size %>" type="image/png" href="<%= File.join favicon_path, "favicon-#{size}.png" %>">
 <%- end -%>

--- a/test/jekyll/favicon/tag_test.rb
+++ b/test/jekyll/favicon/tag_test.rb
@@ -22,11 +22,14 @@ describe Jekyll::Favicon::Tag do
 
     it 'should generate links and meta' do
       index_destination = File.join(@destination, 'index.html')
+      ico_destination = File.join @destination,
+                                  Jekyll::Favicon.config['ico']['path'],
+                                  'favicon.ico'
       assert File.exist? index_destination
+      assert File.exist? ico_destination
       index_document = Nokogiri::Slop File.open(index_destination)
       refute_empty index_document.css('link')
-      assert index_document.at_css('link[href="favicon.ico"]')
-      favicon_path = File.join @site.baseurl, Jekyll::Favicon.config['path'],
+      favicon_path = File.join @site.baseurl, Jekyll::Favicon.config['ico']['path'],
                                'favicon.ico'
       css_selector = 'link[href="' + favicon_path + '"]'
       assert index_document.at_css(css_selector)


### PR DESCRIPTION
This PR makes sure the `href` link to the `favicon.ico` file is correct. Previously it wasn't correct because in case of the `shortcut_icon` it just ignored the path and for the `icon` it prepended the `path` config instead of the `ico/path` config. (But the `favicon.ico` file is written according to the `ico/path` config)

This is achieved by prepending the path from the `ico/path` config to the link.
I also updated the test because it did the same thing and therefore checked that the invalid link got written to the html file and added a check if the `favicon.ico` file is present at the right location.

I discoved this issue with html-proofer when integrating this plugin into my website (See [HedgehogCode/b-wilhelm.de branch: favicons](https://github.com/HedgehogCode/b-wilhelm.de/tree/favicons)). I get the error:
```
- ./_site/404.html
  *  internally linking to /assets/images/favicon.ico, which does not exist (line 1)
     <link rel="icon" sizes="48x48 32x32 16x16" href="/assets/images/favicon.ico">
- ./_site/about/index.html
  *  internally linking to /assets/images/favicon.ico, which does not exist (line 1)
     <link rel="icon" sizes="48x48 32x32 16x16" href="/assets/images/favicon.ico">
  *  internally linking to favicon.ico, which does not exist (line 1)
     <link rel="shortcut icon" href="favicon.ico">
- ./_site/index.html
  *  internally linking to /assets/images/favicon.ico, which does not exist (line 1)
     <link rel="icon" sizes="48x48 32x32 16x16" href="/assets/images/favicon.ico">
- ./_site/my-new-website/index.html
  *  internally linking to /assets/images/favicon.ico, which does not exist (line 1)
     <link rel="icon" sizes="48x48 32x32 16x16" href="/assets/images/favicon.ico">
  *  internally linking to favicon.ico, which does not exist (line 1)
     <link rel="shortcut icon" href="favicon.ico">
- ./_site/site-notice/index.html
  *  internally linking to /assets/images/favicon.ico, which does not exist (line 1)
     <link rel="icon" sizes="48x48 32x32 16x16" href="/assets/images/favicon.ico">
  *  internally linking to favicon.ico, which does not exist (line 1)
     <link rel="shortcut icon" href="favicon.ico">
rake aborted!
HTML-Proofer found 8 failures!
```
Feel free to try it by cloning the repo, checking out the branch and running `bundle exec rake`. With my changes these failuers are gone.