### PR TITLE
Fix travis missing bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.0
-  - 2.4.3
-  - 2.3.6
-  - 2.2.9
+  - 2.6.0
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
+  - 2.2.10
   - 2.1.10
+  - 2.1.0
 before_install:
   - if ! [[ `ruby -v | cut -d' ' -f2` > "2.3" ]]; then gem install bundler -v '< 2'; fi;
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ rvm:
   - 2.3.6
   - 2.2.9
   - 2.1.10
+before_install:
+  - if ! [[ `ruby -v | cut -d' ' -f2` > "2.3" ]]; then gem install bundler -v '< 2'; fi;
 addons:
   apt:
     config:


### PR DESCRIPTION
Fix travis builds by adding a before_install script patching bundler for ruby <2.3