### PR TITLE
Skip safari pinned tab when source is not a SVG. Fixes #16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Skip safari pinned tab when source is not a SVG
 
 ## [0.2.4] - 2018-10-05
 ### Fixed

--- a/lib/jekyll/favicon/templates/safari.html.erb
+++ b/lib/jekyll/favicon/templates/safari.html.erb
@@ -3,4 +3,6 @@
 <%- Favicon.config['apple-touch-icon']['sizes'].each do |size| -%>
   <link rel="apple-touch-icon" sizes="<%= size %>" href="<%= File.join favicon_path, "favicon-#{size}.png" %>">
 <%- end -%>
+<% if  Favicon.config['source'].svg? %>
 <link rel="mask-icon" color="<%= Favicon.config['safari-pinned-tab']['mask-icon-color'] %>" href="<%= File.join favicon_path, 'safari-pinned-tab.svg' %>">
+<% end %>

--- a/test/jekyll/favicon/tag_test.rb
+++ b/test/jekyll/favicon/tag_test.rb
@@ -46,5 +46,35 @@ describe Jekyll::Favicon::Tag do
       css_selector = 'meta[content="' + browserconfig_path + '"]'
       assert @index_document.at_css(css_selector)
     end
+
+    it 'should include safari pinned tag' do
+      pinned_path = File.join @site_baseurl,
+                              Jekyll::Favicon.config['path'],
+                              'safari-pinned-tab.svg'
+      css_selector = 'link[ rel="mask-icon"][href="' + pinned_path + '"]'
+      assert @index_document.at_css(css_selector)
+      assert pinned_path, @index_document.css(css_selector).attribute('href')
+    end
+  end
+
+  describe 'when site uses default PNG favicon' do
+    before :all do
+      @options['source'] = fixture 'sites', 'minimal-png-source'
+      @config = Jekyll.configuration @options
+      @site = Jekyll::Site.new @config
+      @site.process
+      @destination = @options['destination']
+      index_destination = File.join(@destination, 'index.html')
+      @index_document = Nokogiri::Slop File.open(index_destination)
+      @site_baseurl = @site.baseurl || ''
+    end
+
+    it 'should skip safari pinned tag' do
+      pinned_path = File.join @site_baseurl,
+                              Jekyll::Favicon.config['path'],
+                              'safari-pinned-tab.svg'
+      css_selector = 'link[ rel="mask-icon"][href="' + pinned_path + '"]'
+      refute @index_document.at_css(css_selector)
+    end
   end
 end


### PR DESCRIPTION
Add safari-pinned-tab's SVG tag only if favicon source is a SVG