### PR TITLE
Remove alpha convert option for ico. Fixes #19

### DIFF
--- a/lib/jekyll/favicon/icon.rb
+++ b/lib/jekyll/favicon/icon.rb
@@ -57,7 +57,6 @@ module Jekyll
         options = {}
         sizes = Favicon.config['ico']['sizes']
         options[:background] = background_for sizes.first
-        options[:alpha] = 'off'
         options[:resize] = sizes.first
         ico_sizes = sizes.collect { |size| size.split('x').first }.join ','
         options[:define] = "icon:auto-resize=#{ico_sizes}"


### PR DESCRIPTION
ICO backgrounds use background color. Removes alpha conversion option that caused a black background. Tested with a SVG and PNG source.
