### PR TITLE
fix: restore safari-pinned-tab in generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Set default background back to none
+- Restore safari-pinned-tab
 ### Changed
 - Update README outdated stuff
 - Correct typos on README

--- a/lib/jekyll/favicon/generator.rb
+++ b/lib/jekyll/favicon/generator.rb
@@ -46,6 +46,7 @@ module Jekyll
       def generate_icons
         @site.static_files.push ico_icon
         @site.static_files.push(*png_icons)
+        @site.static_files.push(*svg_icons)
       end
 
       def ico_icon
@@ -57,6 +58,15 @@ module Jekyll
         Favicon.config.deep_find('sizes').uniq.collect do |size|
           target = File.join Favicon.config['path'], "favicon-#{size}.png"
           Icon.new @site, Favicon.config['source'], @template.path, target
+        end
+      end
+
+      def svg_icons
+        return [] unless Favicon.config['source'].svg?
+        source = Favicon.config['source']
+        %w[safari-pinned-tab.svg].collect do |name|
+          target = File.join Favicon.config['path'], name
+          Icon.new @site, source, source_path(source), target
         end
       end
 

--- a/test/jekyll/favicon/generator_test.rb
+++ b/test/jekyll/favicon/generator_test.rb
@@ -53,6 +53,14 @@ describe Jekyll::Favicon::Generator do
       end
     end
 
+    it 'will create SVG icon identical to the source' do
+      target = File.join @destination, @defaults['path'],
+                         'safari-pinned-tab.svg'
+      assert File.exist? target
+      source = File.join @site.source, 'favicon.svg'
+      assert_equal File.read(target), File.read(source)
+    end
+
     it 'should honor SVG colors' do
       img = MiniMagick::Image.open File.join @options['destination'], 'assets',
                                              'images',
@@ -128,6 +136,11 @@ describe Jekyll::Favicon::Generator do
         icon = File.join @destination, @defaults['path'], "favicon-#{size}.png"
         assert_includes generated_files, icon
       end
+    end
+
+    it 'will not create SVG icon' do
+      path = File.join @destination, @defaults['path'], 'safari-pinned-tab.svg'
+      refute File.exist? path
     end
 
     it 'should create a webmanifest' do


### PR DESCRIPTION
Restore safari-pinned-tab in generator.
Added test using PNG and SVG sources.
