### PR TITLE
New "crossorigin" option for Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Optional `crossorigin` attribute for Chrome manifest
 
 ## [0.2.8] - 2019-09-11
 ### Changed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ To get the links and meta, just add the favicon tag `{% favicon %}`. For example
 </html>
 ```
 
+#### Unusual situations
+
+If your site is deployed in an unusual way, such as behind HTTP Basic Auth, it might be necessary to specify a `crossorigin` attribute for the webmanifest `<link>` tag:
+
+```yaml
+favicon:
+  chrome:
+    crossorigin: "use-credentials"
+```
+
 ## Development
 
 If you want to add something, just make a PR. There is a lot to do:

--- a/lib/jekyll/favicon/config/defaults.yml
+++ b/lib/jekyll/favicon/config/defaults.yml
@@ -35,6 +35,7 @@ favicon:
         - 192x192
         - 96x96
         - 48x48
+      crossorigin: false
   classic:
     sizes:
       - 16x16

--- a/lib/jekyll/favicon/templates/chrome.html.erb
+++ b/lib/jekyll/favicon/templates/chrome.html.erb
@@ -1,5 +1,6 @@
 <!-- Chrome -->
+<%- @crossorigin = Favicon.config['chrome']['crossorigin'] -%>
 <%- Favicon.config['chrome']['sizes'].each do |size| -%>
   <link rel="icon" sizes="<%= size %>" href="<%= File.join prepend_path, Favicon.config['path'], "favicon-#{size}.png" %>">
 <%- end -%>
-<link rel="manifest" href="<%= File.join prepend_path, Favicon.config['chrome']['manifest']['target'] %>">
+<link rel="manifest" href="<%= File.join prepend_path, Favicon.config['chrome']['manifest']['target'] %>"<%= " crossorigin=\"#{@crossorigin}\"" if @crossorigin %>>

--- a/test/fixtures/sites/custom-config/_config.yml
+++ b/test/fixtures/sites/custom-config/_config.yml
@@ -3,6 +3,7 @@ favicon:
     manifest:
       source: data/source.json
       target: data/target.webmanifest
+    crossorigin: use-credentials
   ie:
     browserconfig:
       source: data/source.xml

--- a/test/jekyll/favicon/tag_test.rb
+++ b/test/jekyll/favicon/tag_test.rb
@@ -55,6 +55,11 @@ describe Jekyll::Favicon::Tag do
       assert @index_document.at_css(css_selector)
       assert pinned_path, @index_document.css(css_selector).attribute('href')
     end
+
+    it 'should not add crossorigin attribute to link tag' do
+      css_selector = 'link[crossorigin]'
+      assert !@index_document.at_css(css_selector)
+    end
   end
 
   describe 'when site uses default PNG favicon' do
@@ -75,6 +80,24 @@ describe Jekyll::Favicon::Tag do
                               'safari-pinned-tab.svg'
       css_selector = 'link[ rel="mask-icon"][href="' + pinned_path + '"]'
       refute @index_document.at_css(css_selector)
+    end
+  end
+
+  describe 'when site defines chrome crossorigin value' do
+    before :all do
+      @options['source'] = fixture 'sites', 'custom-config'
+      @config = Jekyll.configuration @options
+      @site = Jekyll::Site.new @config
+      @site.process
+      @destination = @options['destination']
+      index_destination = File.join(@destination, 'index.html')
+      @index_document = Nokogiri::Slop File.open(index_destination)
+    end
+
+    it 'should add crossorigin attribute to link tag' do
+      crossorigin_config = Jekyll::Favicon.config['chrome']['crossorigin']
+      css_selector = 'link[crossorigin="' + crossorigin_config + '"]'
+      assert @index_document.at_css(css_selector)
     end
   end
 end


### PR DESCRIPTION
Allows setting the `crossorigin` attribute on the `<link>` tag for webmanifest, which might be necessary e.g. when a site is protected by HTTP Basic Auth (Chrome will treat the manifest request as cross-origin and skip sending the credentials unless `crossorigin="use-credentials"` is specified on the link tag).

- Did you...
  - [x] update the Readme? (if needed)
  - [x] update the Changelog? (if needed)
  - [x] update the tests?
  - [x] run the tests?
  - [x] check rubocop?