### PR TITLE
Fix argument error caused by ruby 3.x new way of handling kwargs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,11 @@ jobs:
           gemfile: jekyll36
         - ruby-version: '3.0'
           gemfile: jekyll37
+        - ruby-version: '3.1'
+          gemfile: jekyll36
+        - ruby-version: '3.1'
+          gemfile: jekyll37
 
         gemfile: [ jekyll36, jekyll37, jekyll38, jekyll39, jekyll40, jekyll41, jekyll42 ]
         os: [ ubuntu-latest ]
-        ruby-version: [ 2.6, 2.7, '3.0' ]
+        ruby-version: [ 2.6, 2.7, '3.0', '3.1' ]

--- a/test/unit/jekyll/favicon/test_configuration.rb
+++ b/test/unit/jekyll/favicon/test_configuration.rb
@@ -78,7 +78,7 @@ module Jekyll
       end
 
       def expect_site_config(config = {})
-        @site.expect :config, "favicon" => config
+        @site.expect :config, {"favicon" => config}
         config
       end
     end

--- a/test/unit/jekyll/favicon/test_tag.rb
+++ b/test/unit/jekyll/favicon/test_tag.rb
@@ -38,7 +38,7 @@ module Jekyll
       def setup_site_and_context
         @site = MiniTest::Mock.new
         @context = MiniTest::Mock.new
-        @context.expect :registers, site: @site
+        @context.expect :registers, {site: @site}
       end
 
       def populate_site_static_files

--- a/test/unit/jekyll/test_favicon.rb
+++ b/test/unit/jekyll/test_favicon.rb
@@ -33,7 +33,7 @@ module Jekyll
     end
 
     def test_favicon_assets_retrieves_collection_of_favicon_static_files
-      Favicon::Configuration.stub :merged, "assets" => config_assets do
+      Favicon::Configuration.stub :merged, {"assets" => config_assets} do
         assets = Favicon.assets @site
         assert_kind_of Array, assets
         assert_equal(%w[.png .json .xml],


### PR DESCRIPTION
Fixes keyword arguments compatibility with ruby 3.x by adding parenthesis to the result argument at minitest mock except

https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments

https://www.rubydoc.info/gems/minitest/Minitest/Mock#expect-instance_method
